### PR TITLE
Keep line endings consistent between platforms

### DIFF
--- a/assembly/merge_files.py
+++ b/assembly/merge_files.py
@@ -12,6 +12,18 @@ file_names = [
 
 file_contents = []
 
+import sys
+if sys.version_info < (3, 0):
+    # If we are running Python 2, ignore the 'newline' arg.
+    def wrap(opn):
+        def open_py2(*args, **kwargs):
+            if 'newline' in kwargs:
+                del kwargs['newline'] 
+            return opn(*args, **kwargs)
+        return open_py2
+    open = wrap(open)
+
+
 with open('../nmd_assembly.h', 'w', newline='') as out:
     for file_name in file_names:
         with open(file_name, 'r') as file:

--- a/assembly/merge_files.py
+++ b/assembly/merge_files.py
@@ -12,7 +12,7 @@ file_names = [
 
 file_contents = []
 
-with open('../nmd_assembly.h', 'w') as out:
+with open('../nmd_assembly.h', 'w', newline='') as out:
     for file_name in file_names:
         with open(file_name, 'r') as file:
             # Read file's content


### PR DESCRIPTION
Before this the merge script would add carriage returns on Windows.

I don't know whether you appreciate micro-patches like this. If you do I'd like to make a few to fix some warnings I get with Clang.

Whatever the case, thank you for creating and publishing this code. 