### PR TITLE
Clang warnings on nmd_assembly.h

### DIFF
--- a/assembly/nmd_x86_assembler.c
+++ b/assembly/nmd_x86_assembler.c
@@ -160,7 +160,7 @@ NMD_ASSEMBLY_API bool _nmd_parse_number(const char* string, int64_t* p_num, size
 			{
 				if ((base == _NMD_NUMBER_BASE_DECIMAL && (uint64_t)num >= (uint64_t)1844674407370955162) || /* ceiling((2^64-1) / 10) */
 					(base == _NMD_NUMBER_BASE_HEXADECIMAL && (uint64_t)num >= (uint64_t)1152921504606846976) || /* *ceiling((2^64-1) / 16) */
-					(base == _NMD_NUMBER_BASE_BINARY && (uint64_t)num >= (uint64_t)9223372036854775808)) /* ceiling((2^64-1) / 2) */
+					(base == _NMD_NUMBER_BASE_BINARY && (uint64_t)num >= (uint64_t)9223372036854775808U)) /* ceiling((2^64-1) / 2) */
 				{
 					return false;
 				}

--- a/assembly/nmd_x86_assembler.c
+++ b/assembly/nmd_x86_assembler.c
@@ -1288,7 +1288,7 @@ NMD_ASSEMBLY_API size_t _nmd_assemble_single(_nmd_assemble_info* ai)
 		size_t num_digits = 0;
 		int64_t num = 0;
 		NMD_X86_REG reg;
-		if (reg = _nmd_parse_reg16((const char**)&ai->s))
+		if ((reg = _nmd_parse_reg16((const char**)&ai->s)))
 		{
 			if (ai->mode == NMD_X86_MODE_16)
 			{

--- a/nmd_assembly.h
+++ b/nmd_assembly.h
@@ -4005,7 +4005,7 @@ NMD_ASSEMBLY_API size_t _nmd_assemble_single(_nmd_assemble_info* ai)
 		size_t num_digits = 0;
 		int64_t num = 0;
 		NMD_X86_REG reg;
-		if (reg = _nmd_parse_reg16((const char**)&ai->s))
+		if ((reg = _nmd_parse_reg16((const char**)&ai->s)))
 		{
 			if (ai->mode == NMD_X86_MODE_16)
 			{

--- a/nmd_assembly.h
+++ b/nmd_assembly.h
@@ -2877,7 +2877,7 @@ NMD_ASSEMBLY_API bool _nmd_parse_number(const char* string, int64_t* p_num, size
 			{
 				if ((base == _NMD_NUMBER_BASE_DECIMAL && (uint64_t)num >= (uint64_t)1844674407370955162) || /* ceiling((2^64-1) / 10) */
 					(base == _NMD_NUMBER_BASE_HEXADECIMAL && (uint64_t)num >= (uint64_t)1152921504606846976) || /* *ceiling((2^64-1) / 16) */
-					(base == _NMD_NUMBER_BASE_BINARY && (uint64_t)num >= (uint64_t)9223372036854775808)) /* ceiling((2^64-1) / 2) */
+					(base == _NMD_NUMBER_BASE_BINARY && (uint64_t)num >= (uint64_t)9223372036854775808U)) /* ceiling((2^64-1) / 2) */
 				{
 					return false;
 				}


### PR DESCRIPTION
Gets rid of some default warnings that Clang uses.

Before.
```
$ clang assembly_example.c -o assembly_example
In file included from assembly_example.c:2:
./../nmd_assembly.h:2275:33: warning: '/*' within block comment [-Wcomment]
        /* uint8_t size;               /* The operand's size. (I don't really know what this `size` variable represents or how it would be useful) */
                                       ^
./../nmd_assembly.h:2880:69: warning: integer literal is too large to be represented in a signed integer type, interpreting as unsigned [-Wimplicitly-unsigned-literal]
                                        (base == _NMD_NUMBER_BASE_BINARY && (uint64_t)num >= (uint64_t)9223372036854775808)) /* ceiling((2^64-1) / 2) */
                                                                                                       ^
./../nmd_assembly.h:4008:11: warning: using the result of an assignment as a condition without parentheses [-Wparentheses]
                if (reg = _nmd_parse_reg16((const char**)&ai->s))
                    ~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./../nmd_assembly.h:4008:11: note: place parentheses around the assignment to silence this warning
                if (reg = _nmd_parse_reg16((const char**)&ai->s))
                        ^
                    (                                           )
./../nmd_assembly.h:4008:11: note: use '==' to turn this assignment into an equality comparison
                if (reg = _nmd_parse_reg16((const char**)&ai->s))
                        ^
                        ==
3 warnings generated.
```

Now.
```
$ clang assembly_example.c -o assembly_example
In file included from assembly_example.c:2:
./../nmd_assembly.h:2275:33: warning: '/*' within block comment [-Wcomment]
        /* uint8_t size;               /* The operand's size. (I don't really know what this `size` variable represents or how it would be useful) */
                                       ^
1 warning generated.
```
