### PR TITLE
Fix disassembly of mov drX, reg

### DIFF
--- a/assembly/nmd_x86_decoder.c
+++ b/assembly/nmd_x86_decoder.c
@@ -1182,7 +1182,7 @@ NMD_ASSEMBLY_API bool nmd_x86_decode(const void* const buffer, size_t buffer_siz
 				else if (op >= 0x20 && op <= 0x23)
 				{
 					instruction->operands[0].type = instruction->operands[1].type = NMD_X86_OPERAND_TYPE_REGISTER;
-					instruction->operands[op < 0x22 ? 0 : 1].fields.reg = NMD_X86_REG_EAX + instruction->modrm.fields.rm;
+					instruction->operands[op < 0x22 ? 0 : 1].fields.reg = (uint8_t)(instruction->mode == NMD_X86_MODE_64 ? (instruction->prefixes & NMD_X86_PREFIXES_REX_B ? NMD_X86_REG_R8 : NMD_X86_REG_RAX) : NMD_X86_REG_EAX) + instruction->modrm.fields.rm;
 					instruction->operands[op < 0x22 ? 1 : 0].fields.reg = (uint8_t)((op % 2 == 0 ? NMD_X86_REG_CR0 : NMD_X86_REG_DR0) + instruction->modrm.fields.reg);
 					instruction->operands[0].action = NMD_X86_OPERAND_ACTION_WRITE;
 					instruction->operands[1].action = NMD_X86_OPERAND_ACTION_READ;

--- a/nmd_assembly.h
+++ b/nmd_assembly.h
@@ -5475,7 +5475,7 @@ NMD_ASSEMBLY_API bool nmd_x86_decode(const void* const buffer, size_t buffer_siz
 				else if (op >= 0x20 && op <= 0x23)
 				{
 					instruction->operands[0].type = instruction->operands[1].type = NMD_X86_OPERAND_TYPE_REGISTER;
-					instruction->operands[op < 0x22 ? 0 : 1].fields.reg = NMD_X86_REG_EAX + instruction->modrm.fields.rm;
+					instruction->operands[op < 0x22 ? 0 : 1].fields.reg = (uint8_t)(instruction->mode == NMD_X86_MODE_64 ? (instruction->prefixes & NMD_X86_PREFIXES_REX_B ? NMD_X86_REG_R8 : NMD_X86_REG_RAX) : NMD_X86_REG_EAX) + instruction->modrm.fields.rm;
 					instruction->operands[op < 0x22 ? 1 : 0].fields.reg = (uint8_t)((op % 2 == 0 ? NMD_X86_REG_CR0 : NMD_X86_REG_DR0) + instruction->modrm.fields.reg);
 					instruction->operands[0].action = NMD_X86_OPERAND_ACTION_WRITE;
 					instruction->operands[1].action = NMD_X86_OPERAND_ACTION_READ;


### PR DESCRIPTION
Was using it to handle some privileged instructions and it looks like the rex prefix isn't handled correctly. For some reason the disassembly text was correct, but the structure reported the wrong register.

The code I was using:

https://github.com/mrexodia/driver_unpacking/blob/4f2db064fabfc828549eba80d4b57ce80f0daa43/ntoskrnl/ntoskrnl.cpp#L111-L131